### PR TITLE
Add auth to `server` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
-version = "0.7.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09dbe0e490df5da9d69b36dca48a76635288a82f92eca90024883a56202026d"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -196,9 +196,9 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -219,7 +219,30 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c3220b188aea709cf1b6c5f9b01c3bd936bb08bd2b5184a12b35ac8131b1f9"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -227,11 +250,10 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
- "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -952,7 +974,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "utils",
@@ -1390,25 +1412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "halo2_gadgets"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1461,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -1588,7 +1615,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1613,6 +1639,8 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
+ "tower 0.4.13",
+ "tower-service",
 ]
 
 [[package]]
@@ -2373,7 +2401,7 @@ dependencies = [
  "rayon",
  "serde_json",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "utils",
@@ -2874,6 +2902,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "axum-extra",
  "bincode",
  "clap",
  "constants",
@@ -2883,8 +2912,9 @@ dependencies = [
  "networking",
  "oreo_errors",
  "serde_json",
+ "sha2 0.10.8",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "utils",
@@ -3298,6 +3328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3469,6 +3505,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,15 +3538,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/crates/oreo_errors/src/lib.rs
+++ b/crates/oreo_errors/src/lib.rs
@@ -39,6 +39,8 @@ pub enum OreoError {
     ParseError(String),
     #[error("Decryption server error")]
     DServerError,
+    #[error("Unauthorized")]
+    Unauthorized,
 }
 
 impl IntoResponse for OreoError {
@@ -67,6 +69,7 @@ impl IntoResponse for OreoError {
             OreoError::SeralizeError(_) => (StatusCode::from_u16(612).unwrap(), self.to_string()),
             OreoError::ParseError(_) => (StatusCode::from_u16(613).unwrap(), self.to_string()),
             OreoError::DServerError => (StatusCode::from_u16(614).unwrap(), self.to_string()),
+            OreoError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
         };
         Json(json!({"code": status_code.as_u16(), "error": err_msg})).into_response()
     }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.79"
 axum = { version = "0.7.3", features = ["macros"] }
+axum-extra = { version = "0.9.4", features = ["typed-header"]}
 clap = { version = "4.4.13", features = ["derive"] }
 tokio = { version = "1.35.1", features = ["full"] }
 tower = { version = "0.4.13", features = ["timeout"] }
@@ -22,3 +23,4 @@ serde_json = "1.0.117"
 dotenv = "0.15.0"
 bincode = "1.3.3"
 hex = "0.4.3"
+sha2 = "0.10.8"

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -116,7 +116,6 @@ pub async fn run_server(
         .route("/updateScan", post(update_scan_status_handler))
         .with_state(shared_resource.clone());
 
-    // TODO: remove this once auth is enabled and running for a while
     if env::var("ENABLE_AUTH").unwrap_or_else(|_| "false".to_string()) == "true" {
         auth_router = auth_router.layer(auth_middleware);
     }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -50,6 +50,7 @@ where
         }
     }
 }
+
 // Authentication middleware function
 pub async fn auth<T: DBHandler>(
     State(shared_state): State<Arc<SharedState<T>>>,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,11 +1,11 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{env, net::SocketAddr, sync::Arc, time::Duration};
+use axum_extra::{headers::{authorization::Basic, Authorization}, TypedHeader};
+use sha2::{Sha256, Digest};
+use std::str;
 
 use anyhow::Result;
 use axum::{
-    error_handling::HandleErrorLayer,
-    http::StatusCode,
-    routing::{get, post},
-    BoxError, Router,
+    body::Body, error_handling::HandleErrorLayer, extract::State, http::{Request, StatusCode}, middleware::{from_fn_with_state,  Next}, response::IntoResponse, routing::{get, post}, BoxError, Router
 };
 use db_handler::{DBHandler, PgHandler};
 use networking::{rpc_handler::RpcHandler, server_handler::ServerHandler};
@@ -50,7 +50,33 @@ where
         }
     }
 }
-
+// Authentication middleware function
+pub async fn auth<T: DBHandler>(
+    State(shared_state): State<Arc<SharedState<T>>>,
+    TypedHeader(Authorization(basic)): TypedHeader<Authorization<Basic>>,
+    req: Request<Body>, 
+    next: Next
+) -> impl IntoResponse 
+    where
+    T: DBHandler + Send + Sync + 'static,
+{
+    match shared_state.db_handler.get_account(basic.username().to_string()).await {
+        Ok(account) => {
+            let bytes = hex::decode(account.vk).map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid token"))?;
+            let token = Sha256::digest(bytes);
+            let token_hex = hex::encode(token);
+            if token_hex != basic.password() {
+                return Err((StatusCode::UNAUTHORIZED, "Invalid token"));
+            }
+            return Ok(next.run(req).await);
+        }
+        Err(_) => {
+            // Token is invalid
+            return Err((StatusCode::UNAUTHORIZED, "Invalid token"));
+        }
+    }
+}
+  
 pub async fn run_server(
     listen: SocketAddr,
     rpc_server: String,
@@ -68,9 +94,13 @@ pub async fn run_server(
             pk: pk_u8,
         },
     ));
+    let auth_middleware = from_fn_with_state(shared_resource.clone(), auth);
 
-    let router = Router::new()
+    let no_auth_router = Router::new()
         .route("/import", post(import_account_handler))
+        .with_state(shared_resource.clone());
+
+    let mut auth_router = Router::new()
         .route("/remove", post(remove_account_handler))
         .route("/getBalances", post(get_balances_handler))
         .route("/getTransaction", post(get_transaction_handler))
@@ -83,7 +113,15 @@ pub async fn run_server(
         .route("/rescan", post(rescan_account_handler))
         .route("/healthCheck", get(health_check_handler))
         .route("/updateScan", post(update_scan_status_handler))
-        .with_state(shared_resource.clone())
+        .with_state(shared_resource.clone());
+
+    // TODO: remove this once auth is enabled and running for a while
+    if env::var("ENABLE_AUTH").unwrap_or_else(|_| "false".to_string()) == "true" {
+        auth_router = auth_router.layer(auth_middleware);
+    }
+        
+    let router = no_auth_router
+        .merge(auth_router)
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(|_: BoxError| async {


### PR DESCRIPTION
Adding an auth header protected by viewkey, reasons for using this instead of signed message by private key:

1. No oreowallet with viewkey only, have to use spending key. 
2. No multisig in oreowallet
3. Ledger does not have arbitrary signing, also cannot export spend key.
4. Simplifies backwards compatibility, we can backfill the tokens

NOTE:
Currently gated by `ENABLE_AUTH` env var, this is to prevent breakage of old clients until all clients have been updated to version with auth header.

Related to:
https://github.com/oreoslabs/oreowallet-extension/pull/85
