### PR TITLE
Adds a handler for 404 errors

### DIFF
--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, time::Duration};
 use axum::{
     error_handling::HandleErrorLayer,
     http::StatusCode,
+    response::IntoResponse,
     routing::{get, post},
     BoxError, Router,
 };
@@ -33,7 +34,12 @@ pub async fn run_prover(listen: SocketAddr) -> anyhow::Result<()> {
                 .allow_headers(Any),
         );
     let listener = TcpListener::bind(&listen).await?;
+    let app = router.fallback(handler_404);
     info!("Prover listening on {}", listen);
-    axum::serve(listener, router).await?;
+    axum::serve(listener, app).await?;
     Ok(())
+}
+
+async fn handler_404() -> impl IntoResponse {
+    (StatusCode::NOT_FOUND, "Not Found")
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -138,7 +138,12 @@ pub async fn run_server(
         );
 
     let listener = TcpListener::bind(&listen).await?;
+    let app = router.fallback(handler_404);
     info!("Server listening on {}", listen);
-    axum::serve(listener, router).await?;
+    axum::serve(listener, app).await?;
     Ok(())
+}
+
+async fn handler_404() -> impl IntoResponse {
+    (StatusCode::NOT_FOUND, "Not Found")
 }


### PR DESCRIPTION
At the moment unregistered routes do not return a 404 error.

Follows this as a reference: https://github.com/tokio-rs/axum/blob/main/examples/global-404-handler/src/main.rs