### PR TITLE
Add streaming rpc

### DIFF
--- a/crates/networking/src/lib.rs
+++ b/crates/networking/src/lib.rs
@@ -4,6 +4,7 @@ pub mod rpc_abi;
 pub mod rpc_handler;
 pub mod server_handler;
 pub mod socket_message;
+pub mod stream;
 pub mod web_abi;
 
 use db_handler::{DBTransaction, InnerBlock, Json};

--- a/crates/networking/src/rpc_abi.rs
+++ b/crates/networking/src/rpc_abi.rs
@@ -257,7 +257,7 @@ pub struct RpcGetTransactionsRequest {
     pub reverse: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionStatus {
     pub hash: String,
@@ -281,7 +281,7 @@ pub struct RpcGetAccountTransactionRequest {
     pub notes: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetBalanceDelta {
     pub asset_id: String,

--- a/crates/networking/src/rpc_abi.rs
+++ b/crates/networking/src/rpc_abi.rs
@@ -11,6 +11,11 @@ pub struct RpcResponse<T> {
     pub data: T,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RpcResponseStream<T> {
+    pub data: T
+}
+
 impl<T: Serialize> IntoResponse for RpcResponse<T> {
     fn into_response(self) -> axum::response::Response {
         Json(json!({"code": 200, "data": self.data})).into_response()

--- a/crates/networking/src/stream.rs
+++ b/crates/networking/src/stream.rs
@@ -1,0 +1,94 @@
+use std::io::{BufRead, BufReader, Read};
+use std::marker::PhantomData;
+
+use oreo_errors::OreoError;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use ureq::Response;
+
+use crate::rpc_abi::RpcResponseStream;
+
+pub struct StreamReader<T, R> {
+    reader: BufReader<R>,
+    _marker: PhantomData<T>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ResponseItem<T> {
+    Data(RpcResponseStream<T>),
+    Status { status: u16 },
+}
+
+impl<T, R> StreamReader<T, R> where T: DeserializeOwned, R: Read {
+    pub fn new(reader: R) -> Self {
+      Self {
+          reader: BufReader::new(reader),
+          _marker: PhantomData,
+      }
+    }
+
+    fn read_item(&mut self) -> Result<Option<Vec<u8>>, OreoError> {
+      let mut item = Vec::new();
+      loop {
+          let bytes_read = self.reader.read_until(b'\x0c', &mut item)
+              .map_err(|e| OreoError::RpcStreamError(e.to_string()))?;
+          if bytes_read == 0 {
+              break;
+          }
+          if item.last() == Some(&b'\x0c') {
+              item.pop();
+              break;
+          }
+      }
+      match item.len() {
+          0 => Ok(None),
+          _ => Ok(Some(item))
+      }
+    }
+
+
+    /// Parses a chunk of data into a `ResponseItem<T>`.
+    fn parse_item(&self, chunk: &[u8]) -> Result<Option<T>, OreoError> {
+      match serde_json::from_slice::<ResponseItem<T>>(chunk) {
+          Ok(ResponseItem::Data(item)) => Ok(Some(item.data)),
+          Ok(ResponseItem::Status { status: 200 }) => Ok(None),
+          Ok(ResponseItem::Status { status }) => Err(OreoError::RpcStreamError(format!("Received error status: {}", status))),          
+          Err(e) => {
+              let err_str = format!("Failed to parse JSON object: {:?}", e);
+              Err(OreoError::RpcStreamError(err_str))
+          }
+      }
+  }
+}
+
+impl<T, R> Iterator for StreamReader<T, R>
+where
+    T: DeserializeOwned,
+    R: Read,
+{
+    type Item = Result<T, OreoError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.read_item() {
+            Ok(Some(chunk)) => match self.parse_item(&chunk) {
+                Ok(Some(data)) => Some(Ok(data)),
+                Ok(None) => None, // End of stream
+                Err(e) => Some(Err(e)),
+            },
+            Ok(None) => None, // EOF reached
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+pub trait ResponseExt {
+    fn into_stream<T: DeserializeOwned>(self) -> StreamReader<T, Box<dyn Read + Send + Sync + 'static>>;
+}
+
+impl ResponseExt for Response {
+    fn into_stream<T: DeserializeOwned>(self) -> StreamReader<T, Box<dyn Read + Send + Sync + 'static>> {
+        let reader = self.into_reader();
+        StreamReader::new(Box::new(reader))
+    }
+}

--- a/crates/oreo_errors/src/lib.rs
+++ b/crates/oreo_errors/src/lib.rs
@@ -41,6 +41,8 @@ pub enum OreoError {
     DServerError,
     #[error("Unauthorized")]
     Unauthorized,
+    #[error("RPC stream error")]
+    RpcStreamError(String),
 }
 
 impl IntoResponse for OreoError {
@@ -70,6 +72,7 @@ impl IntoResponse for OreoError {
             OreoError::ParseError(_) => (StatusCode::from_u16(613).unwrap(), self.to_string()),
             OreoError::DServerError => (StatusCode::from_u16(614).unwrap(), self.to_string()),
             OreoError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
+            OreoError::RpcStreamError(_) => (StatusCode::from_u16(615).unwrap(), self.to_string()),
         };
         Json(json!({"code": status_code.as_u16(), "error": err_msg})).into_response()
     }


### PR DESCRIPTION
## Description

`getTransactions` in the [ironfish](https://github.com/iron-fish/ironfish) implementation of the node uses streams. This change is so that `ironfish-optimize` and `ironish` can converge in implementation. In a future PR I will update the `getTransactions` method to use the streams (once use `iron-fish/ironfish` as the rust source.

## Future 
The implementation for the handler will update to something like:
```
    pub fn get_transactions(
        &self,
        request: RpcGetTransactionsRequest,
    ) -> Result<RpcResponse<RpcGetTransactionsResponse>, OreoError> {
        let path = format!("http://{}/wallet/getAccountTransactions", self.endpoint);
        let resp = self.agent.clone().post(&path).send_json(&request);
    
        match resp {
            Ok(response) => {
                let transactions: Result<Vec<_>, OreoError> = response
                    .into_stream::<TransactionStatus>()
                    .collect();
    
                Ok(RpcResponse {
                    status: 200,
                    data: RpcGetTransactionsResponse {
                        transactions: transactions?,
                    },
                })
            }
            Err(e) => Err(OreoError::InternalRpcError(e.to_string())),
        }
    }
```

I did not include this change as it will break API if oreowallet-mono is still using `ironfish-optimize` backend.


## Testing :
I have tested in a local oreowallet against the `iron-fish/ironfish` implementation of the node, it works correctly.
