### PR TITLE
status updates for dservice/dworker decrypted accounts

### DIFF
--- a/crates/dservice/src/manager.rs
+++ b/crates/dservice/src/manager.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::Result;
+use constants::{MAINNET_GENESIS_HASH, MAINNET_GENESIS_SEQUENCE};
 use db_handler::{DBHandler, PgHandler};
 use futures::{SinkExt, StreamExt};
 use networking::{
@@ -266,7 +267,11 @@ impl Manager {
     pub async fn update_account(&self, response: DResponse) -> Result<()> {
         let address = response.address.clone();
         let task_id = response.id.clone();
-        let mut should_clear_account = false;
+        let mut update_account = false;
+        let mut latest_scanned_block = BlockInfo {
+            hash: MAINNET_GENESIS_HASH.to_string(),
+            sequence: MAINNET_GENESIS_SEQUENCE as u64,
+        };
         match self.account_mappling.write().await.get_mut(&address) {
             Some(account) => {
                 if let Some(task_info) = self.task_mapping.read().await.get(&task_id) {
@@ -284,8 +289,14 @@ impl Manager {
                         );
                     }
                     account.remaining_task -= 1;
-                    if account.remaining_task == 0 {
-                        should_clear_account = true;
+                    if account.remaining_task % 5000 == 0 {
+                        update_account = true;
+                    }
+                    if task_info.sequence > latest_scanned_block.sequence as i64 {
+                        latest_scanned_block = BlockInfo {
+                            hash: task_info.hash.clone(),
+                            sequence: task_info.sequence as u64,
+                        };
                     }
                 }
             }
@@ -293,8 +304,7 @@ impl Manager {
                 error!("bad response whose request account doesn't exist, should never happen")
             }
         }
-        if should_clear_account {
-            info!("account scaning completed, {}", address);
+        if update_account {
             let account_info = self
                 .account_mappling
                 .read()
@@ -305,7 +315,8 @@ impl Manager {
             let set_account_head_request = RpcSetAccountHeadRequest {
                 account: address.clone(),
                 start: account_info.start_block.hash.to_string(),
-                end: account_info.end_block.hash.to_string(),
+                end: latest_scanned_block.hash.clone(),
+                scan_complete: account_info.remaining_task == 0,
                 blocks: account_info
                     .blocks
                     .iter()
@@ -326,7 +337,7 @@ impl Manager {
             };
             match self.shared.server_handler.submit_scan_response(request) {
                 Ok(msg) => {
-                    if msg.success {
+                    if msg.success && account_info.end_block.hash == latest_scanned_block.hash {
                         let _ = self.account_mappling.write().await.remove(&address);
                     }
                 }

--- a/crates/networking/src/rpc_abi.rs
+++ b/crates/networking/src/rpc_abi.rs
@@ -99,12 +99,13 @@ pub struct BlockWithHash {
     pub transactions: Vec<TransactionWithHash>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RpcSetAccountHeadRequest {
     pub account: String,
     pub start: String,
     pub end: String,
     pub blocks: Vec<BlockWithHash>,
+    pub scan_complete: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -242,15 +242,18 @@ pub async fn update_scan_status_handler<T: DBHandler>(
             }
             let account = db_account.unwrap();
             message.account = account.name.clone();
+            let scan_complete = message.scan_complete;
             let _ = shared.rpc_handler.set_account_head(message);
-            let _ = shared.rpc_handler.set_scanning(RpcSetScanningRequest {
-                account: account.name.clone(),
-                enabled: true,
-            });
-            let _ = shared
-                .db_handler
-                .update_scan_status(account.address, false)
-                .await;
+            if scan_complete {
+                let _ = shared.rpc_handler.set_scanning(RpcSetScanningRequest {
+                    account: account.name.clone(),
+                    enabled: true,
+                });
+                let _ = shared
+                    .db_handler
+                    .update_scan_status(account.address, false)
+                    .await;
+            }
             return Json(SuccessResponse { success: true }).into_response();
         }
     }


### PR DESCRIPTION
Previously, the sync status is a passthrough api that looks at the node wallet sync status. But the decrypt jobs don't update the node's scan state for a wallet until decryption has happened for all blocks, thus account sync status will go from 0 directly to 100%.

Previously:
- `dservice` waits for all tasks complete
- submits `updateScan` request to `server`
- updates head of account on ironfish node
- changes account to get scanned by node

Now:
- `dservice` every 5000 blocks submits `updateScan` request to `server`
- updates head of account on ironfish node
- if scan complete:
    - changes account to get scanned by node


Tested in local oreowallet:
<img width="355" alt="Screenshot 2024-10-24 at 5 02 34 PM" src="https://github.com/user-attachments/assets/3cdf88f8-8c47-4f5f-952a-8a6fd2933c4b">
