### PR TITLE
cleanup logging and conform to latest iron-fish/ironfish RPC

### DIFF
--- a/crates/dservice/src/manager.rs
+++ b/crates/dservice/src/manager.rs
@@ -219,7 +219,7 @@ impl Manager {
                                             false => {
                                                 let worker = ServerWorker::new(tx.clone());
                                                 worker_name = register.name;
-                                                info!("new worker: {}", worker_name.clone());
+                                                debug!("new worker: {}", worker_name.clone());
                                                 let _ = worker_server.workers.write().await.insert(worker_name.clone(), worker);
                                                 let data = worker_server.task_queue.write().await.pop();
                                                 match data {

--- a/crates/networking/src/rpc_abi.rs
+++ b/crates/networking/src/rpc_abi.rs
@@ -47,6 +47,7 @@ pub struct RpcImportAccountRequest {
     pub outgoing_view_key: String,
     pub public_address: String,
     pub created_at: Option<BlockInfo>,
+    pub spending_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -365,6 +366,7 @@ pub struct RpcGetBlockResponse {
 pub struct RpcGetBlocksRequest {
     pub start: u64,
     pub end: u64,
+    pub serialized: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/networking/src/rpc_handler/handler.rs
+++ b/crates/networking/src/rpc_handler/handler.rs
@@ -193,7 +193,7 @@ impl RpcHandler {
             .agent
             .clone()
             .post(&path)
-            .send_json(RpcGetBlocksRequest { start, end });
+            .send_json(RpcGetBlocksRequest { start, end, serialized: true });
         handle_response(resp)
     }
 

--- a/crates/networking/src/rpc_handler/mod.rs
+++ b/crates/networking/src/rpc_handler/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 mod handler;
 
 pub use handler::*;
+use tracing::error;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RpcError {
@@ -22,7 +23,10 @@ impl TryFrom<RpcError> for OreoError {
                 // Should never happen
                 return Ok(OreoError::Duplicate("0x00".to_string()));
             }
-            _ => Ok(OreoError::InternalRpcError),
+            _ => {
+                error!("Rpc error: {:?}", value);
+                return Ok(OreoError::InternalRpcError(value.message));
+            }
         }
     }
 }

--- a/crates/networking/src/web_abi.rs
+++ b/crates/networking/src/web_abi.rs
@@ -104,7 +104,7 @@ impl TransactionDetail {
                 memo: Some(memo.into()),
                 value: value.into(),
             }),
-            None => Err(OreoError::InternalRpcError),
+            None => Err(OreoError::InternalRpcError("No note found".into())),
         }
     }
 }

--- a/crates/oreo_errors/src/lib.rs
+++ b/crates/oreo_errors/src/lib.rs
@@ -20,7 +20,7 @@ pub enum OreoError {
     #[error("Internal db error")]
     DBError,
     #[error("Internal Ironfish rpc error")]
-    InternalRpcError,
+    InternalRpcError(String),
     #[error("The `{0}` spend circuit can not generate proof")]
     GenerateSpendProofFailed(u32),
     #[error("The `{0}` output circuit can not generate proof")]
@@ -53,7 +53,7 @@ impl IntoResponse for OreoError {
             OreoError::NoImported(_) => (StatusCode::from_u16(602).unwrap(), self.to_string()),
             OreoError::Scanning(_) => (StatusCode::from_u16(603).unwrap(), self.to_string()),
             OreoError::Syncing => (StatusCode::from_u16(604).unwrap(), self.to_string()),
-            OreoError::InternalRpcError => (StatusCode::from_u16(605).unwrap(), self.to_string()),
+            OreoError::InternalRpcError(_) => (StatusCode::from_u16(605).unwrap(), self.to_string()),
             OreoError::GenerateSpendProofFailed(_) => {
                 (StatusCode::from_u16(606).unwrap(), self.to_string())
             }

--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -47,6 +47,7 @@ pub async fn import_account_handler<T: DBHandler>(
         incoming_view_key: incoming_view_key.clone(),
         outgoing_view_key: outgoing_view_key.clone(),
         public_address: public_address.clone(),
+        spending_key: None,
         version: ACCOUNT_VERSION,
         name: account_name.clone(),
         created_at,


### PR DESCRIPTION
Logging was very verbose in a variety of cases, moved to correct logging level. 

Conforms RPC usage (for the most part) to the newest `iron-fish/ironfish` RPC structure. 

Passes through the RPC error via error string/logging.

TODO:
Changes still to be made in future when cutting over node implementation:
- account import RPC request structure update
- use streaming module for `getAccountTransactions`