### PR TITLE
fallback to first note with memo if it is a self sent transaction

### DIFF
--- a/crates/networking/src/web_abi.rs
+++ b/crates/networking/src/web_abi.rs
@@ -71,20 +71,11 @@ impl TransactionDetail {
             asset_balance_deltas,
             notes,
         } = tx;
-        let mut notes = notes.unwrap();
-        let note = match notes
-            .iter()
-            .filter(|asset| asset.owner != asset.sender)
-            .collect::<Vec<&RpcNote>>()
-            .len()
-        {
-            0 => notes.pop(),
-            _ => notes
-                .into_iter()
-                .filter(|asset| asset.owner != asset.sender)
-                .collect::<Vec<RpcNote>>()
-                .pop(),
-        };
+        let notes = notes.unwrap();
+        let note = notes.iter()
+            .find(|asset| asset.owner != asset.sender)
+            .or_else(|| notes.iter().find(|note| !note.memo.is_empty()))
+            .or_else(|| notes.first());
         match note {
             Some(RpcNote {
                 value,


### PR DESCRIPTION
Previously memo was empty for transactions I was sending to myself. This is useful for miners/mining pools and is an additional fail safe.


Tested: split notes or self sent transactions successfully show memos now.