### PR TITLE
broadcast tx -> add tx

### DIFF
--- a/crates/networking/src/rpc_abi.rs
+++ b/crates/networking/src/rpc_abi.rs
@@ -241,15 +241,14 @@ pub struct RpcCreateTxResponse {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct RpcBroadcastTxRequest {
+pub struct RpcAddTxRequest {
     pub transaction: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct RpcBroadcastTxResponse {
+pub struct RpcAddTxResponse {
     pub hash: String,
     pub accepted: bool,
-    pub broadcasted: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/networking/src/rpc_handler/handler.rs
+++ b/crates/networking/src/rpc_handler/handler.rs
@@ -8,7 +8,7 @@ use ureq::{Agent, AgentBuilder, Error, Response};
 
 use crate::{
     rpc_abi::{
-        RpcBroadcastTxRequest, RpcBroadcastTxResponse, RpcCreateTxRequest, RpcCreateTxResponse,
+        RpcAddTxRequest, RpcAddTxResponse, RpcCreateTxRequest, RpcCreateTxResponse,
         RpcExportAccountResponse, RpcGetAccountStatusRequest, RpcGetAccountStatusResponse,
         RpcGetAccountTransactionRequest, RpcGetAccountTransactionResponse, RpcGetBalancesRequest,
         RpcGetBalancesResponse, RpcGetBlockRequest, RpcGetBlockResponse, RpcGetBlocksRequest,
@@ -155,11 +155,11 @@ impl RpcHandler {
         handle_response(resp)
     }
 
-    pub fn broadcast_transaction(
+    pub fn add_transaction(
         &self,
-        request: RpcBroadcastTxRequest,
-    ) -> Result<RpcResponse<RpcBroadcastTxResponse>, OreoError> {
-        let path = format!("http://{}/chain/broadcastTransaction", self.endpoint);
+        request: RpcAddTxRequest,
+    ) -> Result<RpcResponse<RpcAddTxResponse>, OreoError> {
+        let path = format!("http://{}/wallet/addTransaction", self.endpoint);
         let resp = self.agent.clone().post(&path).send_json(&request);
         handle_response(resp)
     }

--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -10,7 +10,7 @@ use db_handler::DBHandler;
 use networking::{
     decryption_message::{DecryptionMessage, ScanRequest, ScanResponse, SuccessResponse},
     rpc_abi::{
-        BlockInfo, OutPut, RpcBroadcastTxRequest, RpcCreateTxRequest, RpcGetAccountStatusRequest,
+        BlockInfo, OutPut, RpcAddTxRequest, RpcCreateTxRequest, RpcGetAccountStatusRequest,
         RpcGetAccountTransactionRequest, RpcGetBalancesRequest, RpcGetBalancesResponse,
         RpcGetTransactionsRequest, RpcImportAccountRequest, RpcImportAccountResponse,
         RpcRemoveAccountRequest, RpcResetAccountRequest, RpcResponse, RpcSetScanningRequest,
@@ -407,13 +407,13 @@ pub async fn create_transaction_handler<T: DBHandler>(
         .into_response()
 }
 
-pub async fn broadcast_transaction_handler<T: DBHandler>(
+pub async fn add_transaction_handler<T: DBHandler>(
     State(shared): State<Arc<SharedState<T>>>,
-    extract::Json(broadcast_transaction): extract::Json<RpcBroadcastTxRequest>,
+    extract::Json(broadcast_transaction): extract::Json<RpcAddTxRequest>,
 ) -> impl IntoResponse {
     shared
         .rpc_handler
-        .broadcast_transaction(broadcast_transaction)
+        .add_transaction(broadcast_transaction)
         .into_response()
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -15,7 +15,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
 
 use crate::handlers::{
-    account_status_handler, broadcast_transaction_handler, create_transaction_handler,
+    account_status_handler, add_transaction_handler, create_transaction_handler,
     get_balances_handler, get_ores_handler, get_transaction_handler, get_transactions_handler,
     health_check_handler, import_account_handler, latest_block_handler, remove_account_handler,
     rescan_account_handler, update_scan_status_handler,
@@ -107,7 +107,8 @@ pub async fn run_server(
         .route("/getTransaction", post(get_transaction_handler))
         .route("/getTransactions", post(get_transactions_handler))
         .route("/createTx", post(create_transaction_handler))
-        .route("/broadcastTx", post(broadcast_transaction_handler))
+        .route("/broadcastTx", post(add_transaction_handler)) // TODO: Remove after front end updates to addTx
+        .route("/addTx", post(add_transaction_handler)) 
         .route("/accountStatus", post(account_status_handler))
         .route("/latestBlock", get(latest_block_handler))
         .route("/ores", post(get_ores_handler))


### PR DESCRIPTION
`chain/broadcastTransaction` does not add the transaction to the wallet's own pending transactions. 

`wallet/addTransaction` both adds the transaction to the wallet and broadcasts it to the chain.

![image](https://github.com/user-attachments/assets/abc020e5-5982-4315-a74a-95d97af4dc2b)
