### PR TITLE
updates local blocks checkpoint to be compatible with testnet

### DIFF
--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -12,4 +12,4 @@ pub const REORG_DEPTH: i64 = 100;
 pub const SECONDARY_BATCH: i64 = 10000;
 pub const RESCHEDULING_DURATION: Duration = Duration::from_secs(30);
 pub const PRIMARY_BATCH: u64 = 100;
-pub const LOCAL_BLOCKS_CHECKPOINT: u64 = 797_000;
+pub const LOCAL_BLOCKS_CHECKPOINT: u64 = 769_000;


### PR DESCRIPTION
This change makes the chainloader compatible with testnet, if we wanted to update for chain loader to run to newest block it would be a much larger change.