### PR TITLE
Fix TLS and update service names in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ WORKDIR /app
 
 # Copy the built binaries from the builder stage
 COPY --from=builder /app/build/target/release/server /app/server
-COPY --from=builder /app/build/target/release/chain_loader /app/chain_loader
-COPY --from=builder /app/build/target/release/dservice /app/dservice
+COPY --from=builder /app/build/target/release/scanner /app/scanner
 COPY --from=builder /app/build/target/release/dworker /app/dworker
 COPY --from=builder /app/build/target/release/prover /app/prover
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y \
     libssl3 \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory


### PR DESCRIPTION
### Changes

* When running sqlx in AWS to an RDS database, I was getting a TLS connection error. Installing openssl in the container instance fixed it.
* Removed `chain_loader` and `dservice` binaries and added `scanner`.