### PR TITLE
Fetch next block for start of next batch

### DIFF
--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -281,8 +281,8 @@ async fn update_scan_status(
             if !limited_blocks.is_empty() && !blocks.is_empty() {
                 let last_block = limited_blocks.last().unwrap();
                 message.end = last_block.hash.clone();
-                let q = shared.db_handler.get_blocks(last_block.sequence, last_block.sequence + 1).await?;
-                start_hash = q[q.len() - 1].hash.clone();
+                let q = shared.rpc_handler.get_blocks(last_block.sequence as u64, last_block.sequence as u64 + 1)?;
+                start_hash = q.data.blocks[q.data.blocks.len() - 1].block.hash.clone();
             }
 
             message.blocks = limited_blocks;


### PR DESCRIPTION
I was noticing that my balance wasn't correct for accounts with many transactions, so I looked into it a bit and found an off-by-one on the batching.

`setAccountHead` is inclusive on both the `start` and `end` parameters, so specifying the same `start` as the `end` of the previous batch will remove the transactions from the `start` block. For example:
* Batch 1: start = 1, end = 5
* Batch 2: start = 5, end = 10

This will result in block 5's transactions not being included. We can solve this by switching Batch 2's start to 6, but since `setAccountHead` takes hashes rather than sequences, we have to do a DB lookup of the hash.

Feel free to change this or suggest changes to the SDK if you'd like to do this differently.