### PR TITLE
Pass through offset to transactions RPC

### DIFF
--- a/crates/networking/src/rpc_abi.rs
+++ b/crates/networking/src/rpc_abi.rs
@@ -264,6 +264,7 @@ pub struct RpcAddTxResponse {
 pub struct RpcGetTransactionsRequest {
     pub account: String,
     pub limit: Option<u32>,
+    pub offset: Option<u32>,
     pub reverse: Option<bool>,
 }
 

--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -430,6 +430,7 @@ pub async fn get_transactions_handler(
         .get_transactions(RpcGetTransactionsRequest {
             account: db_account.unwrap().name,
             limit: Some(get_transactions.limit.unwrap_or(6)),
+            offset: Some(get_transactions.offset.unwrap_or(0)),
             reverse: Some(true),
         })
         .into_response()


### PR DESCRIPTION
Passing through an offset is useful for paginating the list of transactions for accounts with many transactions, rather than using a larger and larger limit as the number of transactions grows.