### PR TITLE
Use wallet-recommended transaction fee by default

### DIFF
--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -469,7 +469,7 @@ pub async fn create_transaction_handler(
         .create_transaction(RpcCreateTxRequest {
             account: db_account.unwrap().name,
             outputs: Some(outputs),
-            fee: Some(create_transaction.fee.unwrap_or("1".into())),
+            fee: create_transaction.fee,
             expiration_delta: Some(create_transaction.expiration_delta.unwrap_or(30)),
             mints: Some(mints),
             burns: Some(burns),


### PR DESCRIPTION
If no transaction fee is passed to the wallet's `createTransaction` RPC, it will default to estimating an appropriate fee based on the transaction size. Even though fees are almost always `1` right now, we should use wallet's default fee rather than hardcoding `1` so that transactions continue to be successful even if transaction fees increase.